### PR TITLE
Add Cantrips A-M, from basic rules

### DIFF
--- a/_posts/spells/cantrips/2020-10-10-spells-0-chill-touch.md
+++ b/_posts/spells/cantrips/2020-10-10-spells-0-chill-touch.md
@@ -1,0 +1,20 @@
+---
+title: Chill Touch
+permalink: "/spells/cantrips/chill-touch/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Sorcerer, Warlock, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Necromancy
+casting-time: "1 Action"
+range: "120 Feet"
+components: "V, S"
+duration: "1 Round"
+---
+
+You create a ghostly, skeletal hand in the space of a creature within range. Make a ranged spell attack against the creature to assail it with the chill of the grave.
+
+On a hit, the target takes 1d8 necrotic damage, and it can’t regain hit points until the start of your next turn. Until then, the hand clings to the target. If you hit an undead target, it also has disadvantage on attack rolls against you until the end of your next turn.
+
+***At Higher Levels.*** You deal an additional 1d8 damage when you reach 5th level, 11th level, and 17th level.

--- a/_posts/spells/cantrips/2020-10-10-spells-0-dancing-lights.md
+++ b/_posts/spells/cantrips/2020-10-10-spells-0-dancing-lights.md
@@ -1,0 +1,18 @@
+---
+title: Dancing Lights
+permalink: "/spells/cantrips/dancing-lights/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Bard, Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Evocation
+casting-time: "1 Action"
+range: "120 Feet"
+components: "V, S, M (A bit of phosphorus or wychwood, or a glowworm)"
+duration: "Concentration, Up to 1 minute"
+---
+
+You create up to four torch-sized lights within range, making them appear as torches, lanterns, or glowing orbs that hover in the air for the duration. You can also combine the four lights into one glowing vaguely humanoid form of Medium size. Whichever form you choose, each light sheds dim light in a 10-foot radius.
+
+As a bonus action on your turn, you can move the lights up to 60 feet to a new spot within range. A light must be within 20 feet of another light created by this spell, and a light winks out if it exceeds the spell’s range.

--- a/_posts/spells/cantrips/2020-10-10-spells-0-druidcraft.md
+++ b/_posts/spells/cantrips/2020-10-10-spells-0-druidcraft.md
@@ -1,0 +1,20 @@
+---
+title: Druidcraft
+permalink: "/spells/cantrips/druidcraft/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Druid]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Transmutation
+casting-time: "1 Action"
+range: "30 Feet"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+Whispering to the spirits of nature, you create one of the following effects within range:
+* You create a tiny, harmless sensory effect that predicts what the weather will be at your location for the next 24 hours. The effect might manifest as a golden orb for clear skies, a cloud for rain, falling snowflakes for snow, and so on. This effect persists for 1 round.
+* You instantly make a flower blossom, a seed pod open, or a leaf bud bloom.
+* You create an instantaneous, harmless sensory effect, such as falling leaves, a puff of wind, the sound of a small animal, or the faint odor of skunk. The effect must fit in a 5-foot cube.
+* You instantly light or snuff out a candle, a torch, or a small campfire.

--- a/_posts/spells/cantrips/2020-10-10-spells-0-eldritch-blast.md
+++ b/_posts/spells/cantrips/2020-10-10-spells-0-eldritch-blast.md
@@ -1,0 +1,18 @@
+---
+title: Eldritch Blast
+permalink: "/spells/cantrips/eldtritch-blast/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Warlock]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Evocation
+casting-time: "1 Action"
+range: "120 Feet"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+A beam of crackling energy streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 force damage.
+
+***At Higher Levels.*** You create an additional beam when you reach 5th level, 11th level, and 17th level. You can direct the beams at the same target or at different ones. Make a separate attack roll for each beam.

--- a/_posts/spells/cantrips/2020-10-10-spells-0-fire-bolt.md
+++ b/_posts/spells/cantrips/2020-10-10-spells-0-fire-bolt.md
@@ -1,0 +1,18 @@
+---
+title: Fire Bolt
+permalink: "/spells/cantrips/fire-bolt/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Evocation
+casting-time: "1 Action"
+range: "120 Feet"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+You hurl a mote of fire at a creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 fire damage. A flammable object hit by this spell ignites if it isn’t being worn or carried.
+
+***At Higher Levels.*** You deal an additional 1d10 damage when you reach 5th level, 11th level, and 17th level.

--- a/_posts/spells/cantrips/2020-10-10-spells-0-guidance.md
+++ b/_posts/spells/cantrips/2020-10-10-spells-0-guidance.md
@@ -1,0 +1,16 @@
+---
+title: Guidance
+permalink: "/spells/cantrips/guidance/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Cleric, Druid]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Divination
+casting-time: "1 Action"
+range: "Touch"
+components: "V, S"
+duration: "Concentration, Up to 1 minute"
+---
+
+You touch one willing creature. Once before the spell ends, the target can roll a d4 and add the number rolled to one ability check of its choice. It can roll the die before or after making the ability check. The spell then ends.

--- a/_posts/spells/cantrips/2020-10-10-spells-0-mage-hand.md
+++ b/_posts/spells/cantrips/2020-10-10-spells-0-mage-hand.md
@@ -1,0 +1,20 @@
+---
+title: Mage Hand
+permalink: "/spells/cantrips/mage-hand/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Bard, Sorcerer, Warlock, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Conjuration
+casting-time: "1 Action"
+range: "30 Feet"
+components: "V, S"
+duration: "1 minute"
+---
+
+A spectral, floating hand appears at a point you choose within range. The hand lasts for the duration or until you dismiss it as an action. The hand vanishes if it is ever more than 30 feet away from you or if you cast this spell again.
+
+You can use your action to control the hand. You can use the hand to manipulate an object, open an unlocked door or container, stow or retrieve an item from an open container, or pour the contents out of a vial. You can move the hand up to 30 feet each time you use it.
+
+The hand can’t attack, activate magic items, or carry more than 10 pounds.

--- a/_posts/spells/cantrips/2020-10-10-spells-0-mending.md
+++ b/_posts/spells/cantrips/2020-10-10-spells-0-mending.md
@@ -1,0 +1,18 @@
+---
+title: Mending
+permalink: "/spells/cantrips/mending/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Bard, Cleric, Druid, Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Transmutation
+casting-time: "1 Minute"
+range: "Touch"
+components: "V, S, M (Two lodestones)"
+duration: "Instantaneous"
+---
+
+This spell repairs a single break or tear in an object you touch, such as a broken chain link, two halves of a broken key, a torn cloak, or a leaking wineskin. As long as the break or tear is no larger than 1 foot in any dimension, you mend it, leaving no trace of the former damage.
+
+This spell can physically repair a magic item or construct, but the spell can’t restore magic to such an object.

--- a/_posts/spells/cantrips/2020-10-10-spells-0-message.md
+++ b/_posts/spells/cantrips/2020-10-10-spells-0-message.md
@@ -1,0 +1,18 @@
+---
+title: Message
+permalink: "/spells/cantrips/message/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Bard, Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Transmutation
+casting-time: "1 Action"
+range: "120 Feet"
+components: "V, S, M (A short piece of copper wire)"
+duration: "1 Round"
+---
+
+You point your finger toward a creature within range and whisper a message. The target (and only the target) hears the message and can reply in a whisper that only you can hear.
+
+You can cast this spell through solid objects if you are familiar with the target and know it is beyond the barrier. Magical silence, 1 foot of stone, 1 inch of common metal, a thin sheet of lead, or 3 feet of wood blocks the spell. The spell doesn’t have to follow a straight line and can travel freely around corners or through openings.

--- a/_posts/spells/cantrips/2020-10-10-spells-0-minor-illusion.md
+++ b/_posts/spells/cantrips/2020-10-10-spells-0-minor-illusion.md
@@ -1,0 +1,22 @@
+---
+title: Minor Illusion
+permalink: "/spells/cantrips/minor-illusion/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Bard, Sorcerer, Warlock, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Illusion
+casting-time: "1 Action"
+range: "30 Feet"
+components: "S, M (A bit of fleece)"
+duration: "1 Minute"
+---
+
+You create a sound or an image of an object within range that lasts for the duration. The illusion also ends if you dismiss it as an action or cast this spell again.
+
+If you create a sound, its volume can range from a whisper to a scream. It can be your voice, someone else’s voice, a lion’s roar, a beating of drums, or any other sound you choose. The sound continues unabated throughout the duration, or you can make discrete sounds at different times before the spell ends.
+
+If you create an image of an object—such as a chair, muddy footprints, or a small chest—it must be no larger than a 5-foot cube. The image can’t create sound, light, smell, or any other sensory effect. Physical interaction with the image reveals it to be an illusion, because things can pass through it.
+
+If a creature uses its action to examine the sound or image, the creature can determine that it is an illusion with a successful Intelligence (Investigation) check against your spell save DC. If a creature discerns the illusion for what it is, the illusion becomes faint to the creature.


### PR DESCRIPTION
Added markdown files for cantrips to spells for those found in basic rules!
This includes:
* Chill Touch
* Dancing Lights
* Druidcraft
* Eldritch Blast
* Fire Bolt
* Guidance
* Mage Hand
* Mending
* Message
* Minor Illusion

Part of https://github.com/magicalmusings/magicalmusings.github.io/issues/20