### PR TITLE
Cantrips N-Z, from basic rules

### DIFF
--- a/_posts/spells/cantrips/2020-10-11-spells-0-poison-spray.md
+++ b/_posts/spells/cantrips/2020-10-11-spells-0-poison-spray.md
@@ -1,0 +1,16 @@
+---
+title: Poison Spray
+permalink: "/spells/cantrips/poison-spray/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Druid, Sorcerer, Warlock, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Conjuration
+casting-time: "1 Action"
+range: "10 Feet"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+You extend your hand toward a creature you can see within range and project a puff of noxious gas from your palm. The creature must succeed on a Constitution saving throw or take 1d12 poison damage.

--- a/_posts/spells/cantrips/2020-10-11-spells-0-prestidigitation.md
+++ b/_posts/spells/cantrips/2020-10-11-spells-0-prestidigitation.md
@@ -1,0 +1,24 @@
+---
+title: Prestidigitation
+permalink: "/spells/cantrips/prestidigitation/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Bard, Sorcerer, Warlock, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Transmutation
+casting-time: "1 Action"
+range: "10 Feet"
+components: "V, S"
+duration: "Up to 1 hour"
+---
+
+This spell is a minor magical trick that novice spellcasters use for practice. You create one of the following magical effects within range:
+* You create an instantaneous, harmless sensory effect, such as a shower of sparks, a puff of wind, faint musical notes, or an odd odor.
+* You instantaneously light or snuff out a candle, a torch, or a small campfire.
+* You instantaneously clean or soil an object no larger than 1 cubic foot.
+* You chill, warm, or flavor up to 1 cubic foot of nonliving material for 1 hour.
+* You make a color, a small mark, or a symbol appear on an object or a surface for 1 hour.
+* You create a nonmagical trinket or an illusory image that can fit in your hand and that lasts until the end of your next turn.
+
+If you cast this spell multiple times, you can have up to three of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.

--- a/_posts/spells/cantrips/2020-10-11-spells-0-produce-flame.md
+++ b/_posts/spells/cantrips/2020-10-11-spells-0-produce-flame.md
@@ -1,0 +1,18 @@
+---
+title: Produce Flame
+permalink: "/spells/cantrips/produce-flame/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Druid]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Conjuration
+casting-time: "1 Action"
+range: "Self"
+components: "V, S"
+duration: "10 Minutes"
+---
+
+A flickering flame appears in your hand. The flame remains there for the duration and harms neither you nor your equipment. The flame sheds bright light in a 10-foot radius and dim light for an additional 10 feet. The spell ends if you dismiss it as an action or if you cast it again.
+
+You can also attack with the flame, although doing so ends the spell. When you cast this spell, or as an action on a later turn, you can hurl the flame at a creature within 30 feet of you. Make a ranged spell attack. On a hit, the target takes 1d8 fire damage.

--- a/_posts/spells/cantrips/2020-10-11-spells-0-ray-of-frost.md
+++ b/_posts/spells/cantrips/2020-10-11-spells-0-ray-of-frost.md
@@ -1,0 +1,16 @@
+---
+title: Ray of Frost
+permalink: "/spells/cantrips/ray-of-frost/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Evocation
+casting-time: "1 Action"
+range: "60 Feet"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+A frigid beam of blue-white light streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, it takes 1d8 cold damage, and its speed is reduced by 10 feet until the start of your next turn.

--- a/_posts/spells/cantrips/2020-10-11-spells-0-sacred-flame.md
+++ b/_posts/spells/cantrips/2020-10-11-spells-0-sacred-flame.md
@@ -1,0 +1,16 @@
+---
+title: Sacred Flame
+permalink: "/spells/cantrips/sacred-flame/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Cleric]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Evocation
+casting-time: "1 Action"
+range: "60 Feet"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+Flame-like radiance descends on a creature that you can see within range. The target must succeed on a Dexterity saving throw or take 1d8 radiant damage. The target gains no benefit from cover for this saving throw.

--- a/_posts/spells/cantrips/2020-10-11-spells-0-shillelagh.md
+++ b/_posts/spells/cantrips/2020-10-11-spells-0-shillelagh.md
@@ -1,0 +1,16 @@
+---
+title: Shillelagh
+permalink: "/spells/cantrips/shillelagh/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Druid]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Transmutation
+casting-time: "1 Action"
+range: "Touch"
+components: "V, S, M (Mistletoe, a shamrock leaf, and a club or quarterstaff)"
+duration: "1 Minute"
+---
+
+The wood of a club or quarterstaff you are holding is imbued with nature’s power. For the duration, you can use your spellcasting ability instead of Strength for the attack and damage rolls of melee attacks using that weapon, and the weapon’s damage die becomes a d8. The weapon also becomes magical, if it isn’t already. The spell ends if you cast it again or if you let go of the weapon.

--- a/_posts/spells/cantrips/2020-10-11-spells-0-shocking-grasp.md
+++ b/_posts/spells/cantrips/2020-10-11-spells-0-shocking-grasp.md
@@ -1,0 +1,16 @@
+---
+title: Shocking Grasp
+permalink: "/spells/cantrips/shocking-grasp/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Evocation
+casting-time: "1 Action"
+range: "Touch"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+Lightning springs from your hand to deliver a shock to a creature you try to touch. Make a melee spell attack against the target. You have advantage on the attack roll if the target is wearing armor made of metal. On a hit, the target takes 1d8 lightning damage, and it can’t take reactions until the start of its next turn.

--- a/_posts/spells/cantrips/2020-10-11-spells-0-spare-the-dying.md
+++ b/_posts/spells/cantrips/2020-10-11-spells-0-spare-the-dying.md
@@ -1,0 +1,16 @@
+---
+title: Spare the Dying
+permalink: "/spells/cantrips/spare-the-dying/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Cleric]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Evocation
+casting-time: "1 Action"
+range: "Touch"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+You touch a living creature that has 0 hit points. The creature becomes stable. This spell has no effect on undead or constructs.

--- a/_posts/spells/cantrips/2020-10-11-spells-0-thaumaturgy.md
+++ b/_posts/spells/cantrips/2020-10-11-spells-0-thaumaturgy.md
@@ -1,0 +1,24 @@
+---
+title: Thaumaturgy
+permalink: "/spells/cantrips/thaumaturgy/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Cleric]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Transmutation
+casting-time: "1 Action"
+range: "30 Feet"
+components: "V"
+duration: "Up to 1 Minute"
+---
+
+You manifest a minor wonder, a sign of supernatural power, within range. You create one of the following magical effects within range:
+* Your voice booms up to three times as loud as normal for 1 minute.
+* You cause flames to flicker, brighten, dim, or change color for 1 minute.
+* You cause harmless tremors in the ground for 1 minute.
+* You create an instantaneous sound that originates from a point of your choice within range, such as a rumble of thunder, the cry of a raven, or ominous whispers.
+* You instantaneously cause an unlocked door or window to fly open or slam shut.
+* You alter the appearance of your eyes for 1 minute.
+
+If you cast this spell multiple times, you can have up to three of its 1-minute effects active at a time, and you can dismiss such an effect as an action.

--- a/_posts/spells/cantrips/2020-10-11-spells-0-true-strike.md
+++ b/_posts/spells/cantrips/2020-10-11-spells-0-true-strike.md
@@ -1,0 +1,16 @@
+---
+title: True Strike
+permalink: "/spells/cantrips/true-strike/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Bard, Sorcerer, Warlock, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Divination
+casting-time: "1 Action"
+range: "30 Feet"
+components: "S"
+duration: "Concentration, Up to 1 round"
+---
+
+You extend your hand and point a finger at a target in range. Your magic grants you a brief insight into the target’s defenses. On your next turn, you gain advantage on your first attack roll against the target, provided that this spell hasn’t ended.

--- a/_posts/spells/cantrips/2020-10-11-spells-0-vicious-mockery.md
+++ b/_posts/spells/cantrips/2020-10-11-spells-0-vicious-mockery.md
@@ -1,0 +1,16 @@
+---
+title: Vicious Mockery
+permalink: "/spells/cantrips/vicious-mockery/"
+layout: spell-post
+categories: [Spells, Cantrips]
+tags: [Bard]
+source: "Basic Rules (PHB)"
+spell-level: Cantrip
+school: Enchantment
+casting-time: "1 Action"
+range: "60 Feet"
+components: "V"
+duration: "Instantaneous"
+---
+
+You unleash a string of insults laced with subtle enchantments at a creature you can see within range. If the target can hear you (though it need not understand you), it must succeed on a Wisdom saving throw or take 1d4 psychic damage and have disadvantage on the next attack roll it makes before the end of its next turn.


### PR DESCRIPTION
Added markdown files for cantrips to spells for those found in basic rules!
This includes:
* Poison Spray
* Prestidigitation
* Produce Flame
* Ray of Frost
* Sacred Flame
* Shillelagh
* Shocking Grasp
* Spare the Dying
* Thaumaturgy
* True Strike
* Vicious Mockery
Part of https://github.com/magicalmusings/magicalmusings.github.io/issues/20