### PR TITLE
1st level spells E-Z, from basic rules

### DIFF
--- a/_posts/spells/first-level/2020-10-12-spells-1-entangle.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-entangle.md
@@ -1,0 +1,20 @@
+---
+title: Entangle
+permalink: "/spells/first-level/entangle/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Druid]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Conjuration
+casting-time: "1 Action"
+range: "90 Feet"
+components: "V, S"
+duration: "Concentration, Up to 1 minute"
+---
+
+Grasping weeds and vines sprout from the ground in a 20-foot square starting from a point within range. For the duration, these plants turn the ground in the area into difficult terrain.
+
+A creature in the area when you cast the spell must succeed on a Strength saving throw or be restrained by the entangling plants until the spell ends. A creature restrained by the plants can use its action to make a Strength check against your spell save DC. On a success, it frees itself.
+
+When the spell ends, the conjured plants wilt away.

--- a/_posts/spells/first-level/2020-10-12-spells-1-expeditious-retreat.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-expeditious-retreat.md
@@ -1,0 +1,16 @@
+---
+title: Expeditious Retreat
+permalink: "/spells/first-level/expeditious-retreat/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Sorcerer, Warlock, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Transmutation
+casting-time: "1 Bonus Action"
+range: "Self"
+components: "V, S"
+duration: "Concentration, Up to 10 minutes"
+---
+
+This spell allows you to move at an incredible pace. When you cast this spell, and then as a bonus action on each of your turns until the spell ends, you can take the Dash action.

--- a/_posts/spells/first-level/2020-10-12-spells-1-faerie-fire.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-faerie-fire.md
@@ -1,0 +1,18 @@
+---
+title: Faerie Fire
+permalink: "/spells/first-level/faerie-fire/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Druid]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Evocation
+casting-time: "1 Action"
+range: "60 Feet"
+components: "V"
+duration: "Concentration, Up to 1 minute"
+---
+
+Each object in a 20-foot cube within range is outlined in blue, green, or violet light (your choice). Any creature in the area when the spell is cast is also outlined in light if it fails a Dexterity saving throw. For the duration, objects and affected creatures shed dim light in a 10-foot radius.
+
+Any attack roll against an affected creature or object has advantage if the attacker can see it, and the affected creature or object can’t benefit from being invisible.

--- a/_posts/spells/first-level/2020-10-12-spells-1-false-life.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-false-life.md
@@ -1,0 +1,18 @@
+---
+title: False Life
+permalink: "/spells/first-level/false-life/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Necromancy
+casting-time: "1 Action"
+range: "Self"
+components: "V, S, M (A small amount of alcohol or distilled spirits)"
+duration: "1 Hour"
+---
+
+Bolstering yourself with a necromantic facsimile of life, you gain 1d4 + 4 temporary hit points for the duration.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 2nd level or higher, you gain an additional 5 Temporary Hit Points for each slot level above 1st.

--- a/_posts/spells/first-level/2020-10-12-spells-1-feather-fall.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-feather-fall.md
@@ -1,0 +1,16 @@
+---
+title: Feather Fall
+permalink: "/spells/first-level/feather-fall/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Transmutation
+casting-time: "1 Reaction, which you take when you or a creature within 60 feet of you falls"
+range: "60 Feet"
+components: "V, M (A small feather or piece of down)"
+duration: "1 Minute"
+---
+
+Choose up to five falling creatures within range. A falling creature’s rate of descent slows to 60 feet per round until the spell ends. If the creature lands before the spell ends, it takes no falling damage and can land on its feet, and the spell ends for that creature.

--- a/_posts/spells/first-level/2020-10-12-spells-1-find-familiar.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-find-familiar.md
@@ -1,0 +1,28 @@
+---
+title: Find Familiar
+permalink: "/spells/first-level/find-familiar/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Conjuration (ritual)
+casting-time: "1 Hour"
+range: "10 Feet"
+components: "V, S, M (10 gp worth of charcoal, incense, and herbs that must be consumed by fire in a brass brazier)"
+duration: "Instantaneous"
+---
+
+You gain the service of a familiar, a spirit that takes an animal form you choose: bat, cat, crab, frog (toad), hawk, lizard, octopus, owl, poisonous snake, fish (quipper), rat, raven, sea horse, spider, or weasel. Appearing in an unoccupied space within range, the familiar has the statistics of the chosen form, though it is a celestial, fey, or fiend (your choice) instead of a beast.
+
+Your familiar acts independently of you, but it always obeys your commands. In combat, it rolls its own initiative and acts on its own turn. A familiar can’t attack, but it can take other actions as normal.
+
+When the familiar drops to 0 hit points, it disappears, leaving behind no physical form. It reappears after you cast this spell again.
+
+While your familiar is within 100 feet of you, you can communicate with it telepathically. Additionally, as an action, you can see through your familiar’s eyes and hear what it hears until the start of your next turn, gaining the benefits of any special senses that the familiar has. During this time, you are deaf and blind with regard to your own senses.
+
+As an action, you can temporarily dismiss your familiar. It disappears into a pocket dimension where it awaits your summons. Alternatively, you can dismiss it forever. As an action while it is temporarily dismissed, you can cause it to reappear in any unoccupied space within 30 feet of you.
+
+You can’t have more than one familiar at a time. If you cast this spell while you already have a familiar, you instead cause it to adopt a new form. Choose one of the forms from the above list. Your familiar transforms into the chosen creature.
+
+Finally, when you cast a spell with a range of touch, your familiar can deliver the spell as if it had cast the spell. Your familiar must be within 100 feet of you, and it must use its reaction to deliver the spell when you cast it. If the spell requires an attack roll, you use your attack modifier for the roll.

--- a/_posts/spells/first-level/2020-10-12-spells-1-fog-cloud.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-fog-cloud.md
@@ -1,0 +1,18 @@
+---
+title: Fog Cloud
+permalink: "/spells/first-level/fog-cloud/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Druid, Ranger, Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Conjuration
+casting-time: "1 Action"
+range: "120 Feet"
+components: "V, S"
+duration: "Concentration, Up to 1 hour"
+---
+
+You create a 20-foot-radius sphere of fog centered on a point within range. The sphere spreads around corners, and its area is heavily obscured. It lasts for the duration or until a wind of moderate or greater speed (at least 10 miles per hour) disperses it.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 2nd level or higher, the radius of the fog increases by 20 feet for each slot level above 1st.

--- a/_posts/spells/first-level/2020-10-12-spells-1-goodberry.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-goodberry.md
@@ -1,0 +1,18 @@
+---
+title: Goodberry
+permalink: "/spells/first-level/goodberry/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Druid, Ranger]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Transmutation
+casting-time: "1 Action"
+range: "Touch"
+components: "V, S, M (A sprig of mistletoe)"
+duration: "Instantaneous"
+---
+
+Up to ten berries appear in your hand and are infused with magic for the duration. A creature can use its action to eat one berry. Eating a berry restores 1 hit point, and the berry provides enough nourishment to sustain a creature for one day.
+
+The berries lose their potency if they have not been consumed within 24 hours of the casting of this spell.

--- a/_posts/spells/first-level/2020-10-12-spells-1-grease.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-grease.md
@@ -1,0 +1,18 @@
+---
+title: Grease
+permalink: "/spells/first-level/grease/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Conjuration
+casting-time: "1 Action"
+range: "60 Feet"
+components: "V, S, M (A bit of pork rind or butter)"
+duration: "1 Minute"
+---
+
+Slick grease covers the ground in a 10-foot square centered on a point within range and turns it into difficult terrain for the duration.
+
+When the grease appears, each creature standing in its area must succeed on a Dexterity saving throw or fall prone. A creature that enters the area or ends its turn there must also succeed on a Dexterity saving throw or fall prone.

--- a/_posts/spells/first-level/2020-10-12-spells-1-guiding-bolt.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-guiding-bolt.md
@@ -1,0 +1,18 @@
+---
+title: Guiding Bolt
+permalink: "/spells/first-level/guiding-bolt/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Cleric]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Evocation
+casting-time: "1 Action"
+range: "120 Feet"
+components: "V, S"
+duration: "1 Round"
+---
+
+A flash of light streaks toward a creature of your choice within range. Make a ranged spell attack against the target. On a hit, the target takes 4d6 radiant damage, and the next attack roll made against this target before the end of your next turn has advantage, thanks to the mystical dim light glittering on the target until then.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.

--- a/_posts/spells/first-level/2020-10-12-spells-1-healing-word.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-healing-word.md
@@ -1,0 +1,18 @@
+---
+title: Healing Word
+permalink: "/spells/first-level/healing-word/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Cleric, Druid]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Evocation
+casting-time: "1 Bonus Action"
+range: "60 Feet"
+components: "V"
+duration: "Instantaneous"
+---
+
+A creature of your choice that you can see within range regains hit points equal to 1d4 + your spellcasting ability modifier. This spell has no effect on undead or constructs.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 2nd level or higher, you Heal an additional 1d4 for each slot level above 1st.

--- a/_posts/spells/first-level/2020-10-12-spells-1-hellish-rebuke.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-hellish-rebuke.md
@@ -1,0 +1,18 @@
+---
+title: Hellish Rebuke
+permalink: "/spells/first-level/hellish-rebuke/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Warlock]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Evocation
+casting-time: "1 reaction, which you take in response to being damaged by a creature within 60 feet of you that you can see"
+range: "60 Feet"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+You point your finger, and the creature that damaged you is momentarily surrounded by hellish flames. The creature must make a Dexterity saving throw. It takes 2d10 fire damage on a failed save, or half as much damage on a successful one.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 2nd level or higher, you deal an additional 1d10 damage for each slot level above 1st.

--- a/_posts/spells/first-level/2020-10-12-spells-1-heroism.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-heroism.md
@@ -1,0 +1,18 @@
+---
+title: Heroism
+permalink: "/spells/first-level/heroism/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Paladin]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Enchantment
+casting-time: "1 Action"
+range: "Touch"
+components: "V, S"
+duration: "Concentration, Up to 1 minute"
+---
+
+A willing creature you touch is imbued with bravery. Until the spell ends, the creature is immune to being frightened and gains temporary hit points equal to your spellcasting ability modifier at the start of each of its turns. When the spell ends, the target loses any remaining temporary hit points from this spell.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st.

--- a/_posts/spells/first-level/2020-10-12-spells-1-hunters-mark.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-hunters-mark.md
@@ -1,0 +1,18 @@
+---
+title: Hunter's Mark
+permalink: "/spells/first-level/hunters-mark/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Ranger]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Divination
+casting-time: "1 Bonus Action"
+range: "90 Feet"
+components: "V"
+duration: "Concentration, Up to 1 hour"
+---
+
+You choose a creature you can see within range and mystically mark it as your quarry. Until the spell ends, you deal an extra 1d6 damage to the target whenever you hit it with a weapon attack, and you have advantage on any Wisdom (Perception) or Wisdom (Survival) check you make to find it. If the target drops to 0 hit points before this spell ends, you can use a bonus action on a subsequent turn of yours to mark a new creature.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 3rd or 4th level, you can maintain your Concentration on the spell for up to 8 hours. When you use a spell slot of 5th level or higher, you can maintain your concentr⁠ation on the spell for up to 24 hours.

--- a/_posts/spells/first-level/2020-10-12-spells-1-identify.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-identify.md
@@ -1,0 +1,18 @@
+---
+title: Identify
+permalink: "/spells/first-level/identify/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Divination (ritual)
+casting-time: "1 Minute"
+range: "Touch"
+components: "V, S, M (A pearl worth at least 100 gp and an owl feather)"
+duration: "Instantaneous"
+---
+
+You choose one object that you must touch throughout the casting of the spell. If it is a magic item or some other magic-imbued object, you learn its properties and how to use them, whether it requires attunement to use, and how many charges it has, if any. You learn whether any spells are affecting the item and what they are. If the item was created by a spell, you learn which spell created it.
+
+If you instead touch a creature throughout the casting, you learn what spells, if any, are currently affecting it.

--- a/_posts/spells/first-level/2020-10-12-spells-1-illusory-script.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-illusory-script.md
@@ -1,0 +1,22 @@
+---
+title: Illusory Script
+permalink: "/spells/first-level/illusory-script/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Warlock, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Illusion (ritual)
+casting-time: "1 Minute"
+range: "Touch"
+components: "V, S, M (A lead-based ink worth at least 10 gp, which the spell consumes)"
+duration: "10 Days"
+---
+
+You write on parchment, paper, or some other suitable writing material and imbue it with a potent illusion that lasts for the duration.
+
+To you and any creatures you designate when you cast the spell, the writing appears normal, written in your hand, and conveys whatever meaning you intended when you wrote the text. To all others, the writing appears as if it were written in an unknown or magical script that is unintelligible. Alternatively, you can cause the writing to appear to be an entirely different message, written in a different hand and language, though the language must be one you know.
+
+Should the spell be dispelled, the original script and the illusion both disappear.
+
+A creature with truesight can read the hidden message.

--- a/_posts/spells/first-level/2020-10-12-spells-1-inflict-wounds.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-inflict-wounds.md
@@ -1,0 +1,18 @@
+---
+title: Inflict Wounds
+permalink: "/spells/first-level/inflict-wounds/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Cleric]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Necromancy
+casting-time: "1 Action"
+range: "Touch"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+Make a melee spell attack against a creature you can reach. On a hit, the target takes 3d10 necrotic damage.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 2nd level or higher, you deal an additional 1d10 damage for each slot level above 1st.

--- a/_posts/spells/first-level/2020-10-12-spells-1-jump.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-jump.md
@@ -1,0 +1,16 @@
+---
+title: Jump
+permalink: "/spells/first-level/jump/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Druid, Ranger, Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Transmutation
+casting-time: "1 Action"
+range: "Touch"
+components: "V, S, M (A grasshopper's hind leg)"
+duration: "1 Minute"
+---
+
+You touch a creature. The creature’s jump distance is tripled until the spell ends.

--- a/_posts/spells/first-level/2020-10-12-spells-1-longstrider.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-longstrider.md
@@ -1,0 +1,18 @@
+---
+title: Longstrider
+permalink: "/spells/first-level/longstrider/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Druid, Ranger, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Transmutation
+casting-time: "1 Action"
+range: "Touch"
+components: "V, S, M (A pinch of dirt)"
+duration: "1 Hour"
+---
+
+You touch a creature. The target’s speed increases by 10 feet until the spell ends.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st.

--- a/_posts/spells/first-level/2020-10-12-spells-1-mage-armor.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-mage-armor.md
@@ -1,0 +1,16 @@
+---
+title: Mage Armor
+permalink: "/spells/first-level/mage-armor/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Abjuration
+casting-time: "1 Action"
+range: "Touch"
+components: "V, S, M (A piece of cured leather)"
+duration: "8 Hours"
+---
+
+You touch a willing creature who isn’t wearing armor, and a protective magical force surrounds it until the spell ends. The target’s base AC becomes 13 + its Dexterity modifier. The spell ends if the target dons armor or if you dismiss the spell as an action.

--- a/_posts/spells/first-level/2020-10-12-spells-1-magic-missile.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-magic-missile.md
@@ -1,0 +1,18 @@
+---
+title: Magic Missile
+permalink: "/spells/first-level/magic-missile/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Evocation
+casting-time: "1 Action"
+range: "120 Feet"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+You create three glowing darts of magical force. Each dart hits a creature of your choice that you can see within range. A dart deals 1d4 + 1 force damage to its target. The darts all strike simultaneously, and you can direct them to hit one creature or several.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 2nd level or higher, the spell creates one more dart for each slot above 1st.

--- a/_posts/spells/first-level/2020-10-12-spells-1-protection-from-evil-and-good.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-protection-from-evil-and-good.md
@@ -1,0 +1,18 @@
+---
+title: Protection From Evil and Good
+permalink: "/spells/first-level/protection-from-evil-and-good/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Cleric, Paladin, Warlock, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Abjuration
+casting-time: "1 Action"
+range: "Touch"
+components: "V, S, M (Holy water or powdered silver and iron, which the spell consumes)"
+duration: "Concentration, Up to 10 minutes"
+---
+
+Until the spell ends, one willing creature you touch is protected against certain types of creatures: aberrations, celestials, elementals, fey, fiends, and undead.
+
+The protection grants several benefits. Creatures of those types have disadvantage on attack rolls against the target. The target also can’t be charmed, frightened, or possessed by them. If the target is already charmed, frightened, or possessed by such a creature, the target has advantage on any new saving throw against the relevant effect.

--- a/_posts/spells/first-level/2020-10-12-spells-1-purify-food-and-drink.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-purify-food-and-drink.md
@@ -1,0 +1,16 @@
+---
+title: Purify Food and Drink
+permalink: "/spells/first-level/purify-food-and-drink/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Cleric, Druid, Paladin]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Transmutation (ritual)
+casting-time: "1 Action"
+range: "10 Feet"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+All nonmagical food and drink within a 5-foot-radius sphere centered on a point of your choice within range is purified and rendered free of poison and disease.

--- a/_posts/spells/first-level/2020-10-12-spells-1-sanctuary.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-sanctuary.md
@@ -1,0 +1,18 @@
+---
+title: Sanctuary
+permalink: "/spells/first-level/sanctuary/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Cleric]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Abjuration
+casting-time: "1 Bonus Action"
+range: "30 Feet"
+components: "V, S, M (A small silver mirror)"
+duration: "1 Minute"
+---
+
+You ward a creature within range against attack. Until the spell ends, any creature who targets the warded creature with an attack or a harmful spell must first make a Wisdom saving throw. On a failed save, the creature must choose a new target or lose the attack or spell. This spell doesn’t protect the warded creature from area effects, such as the explosion of a fireball.
+
+If the warded creature makes an attack or casts a spell that affects an enemy creature, this spell ends.

--- a/_posts/spells/first-level/2020-10-12-spells-1-shield-of-faith.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-shield-of-faith.md
@@ -1,0 +1,16 @@
+---
+title: Shield of Faith
+permalink: "/spells/first-level/shield-of-faith/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Cleric, Paladin]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Abjuration
+casting-time: "1 Bonus Action"
+range: "60 Feet"
+components: "V, S, M (A small parchment with a bit of holy text written on it)"
+duration: "Concentration, Up to 10 minutes"
+---
+
+A shimmering field appears and surrounds a creature of your choice within range, granting it a +2 bonus to AC for the duration.

--- a/_posts/spells/first-level/2020-10-12-spells-1-shield.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-shield.md
@@ -1,0 +1,16 @@
+---
+title: Shield
+permalink: "/spells/first-level/shield/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Abjuration
+casting-time: "1 reaction, which you take when you are hit by an attack or targeted by the magic missile spell"
+range: "Self"
+components: "V, S"
+duration: "1 Round"
+---
+
+An invisible barrier of magical force appears and protects you. Until the start of your next turn, you have a +5 bonus to AC, including against the triggering attack, and you take no damage from magic missile.

--- a/_posts/spells/first-level/2020-10-12-spells-1-silent-image.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-silent-image.md
@@ -1,0 +1,20 @@
+---
+title: Silent Image
+permalink: "/spells/first-level/silent-image/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Illusion
+casting-time: "1 Action"
+range: "60 Feet"
+components: "V, S, M (A bit of fleece)"
+duration: "Concentration, Up to 10 minutes"
+---
+
+You create the image of an object, a creature, or some other visible phenomenon that is no larger than a 15-foot cube. The image appears at a spot within range and lasts for the duration. The image is purely visual; it isn’t accompanied by sound, smell, or other sensory effects.
+
+You can use your action to cause the image to move to any spot within range. As the image changes location, you can alter its appearance so that its movements appear natural for the image. For example, if you create an image of a creature and move it, you can alter the image so that it appears to be walking.
+
+Physical interaction with the image reveals it to be an illusion, because things can pass through it. A creature that uses its action to examine the image can determine that it is an illusion with a successful Intelligence (Investigation) check against your spell save DC. If a creature discerns the illusion for what it is, the creature can see through the image.

--- a/_posts/spells/first-level/2020-10-12-spells-1-sleep.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-sleep.md
@@ -1,0 +1,22 @@
+---
+title: Sleep
+permalink: "/spells/first-level/sleep/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Enchantment
+casting-time: "1 Action"
+range: "90 Feet"
+components: "V, S, M (A pinch of fine sand, rose petals, or a cricket)"
+duration: "1 Minute"
+---
+
+This spell sends creatures into a magical slumber. Roll 5d8; the total is how many hit points of creatures this spell can affect. Creatures within 20 feet of a point you choose within range are affected in ascending order of their current hit points (ignoring unconscious creatures).
+
+Starting with the creature that has the lowest current hit points, each creature affected by this spell falls unconscious until the spell ends, the sleeper takes damage, or someone uses an action to shake or slap the sleeper awake. Subtract each creature’s hit points from the total before moving on to the creature with the next lowest hit points. A creature’s hit points must be equal to or less than the remaining total for that creature to be affected.
+
+Undead and creatures immune to being charmed aren’t affected by this spell.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 2nd level or higher, roll an additional 2d8 for each slot level above 1st.

--- a/_posts/spells/first-level/2020-10-12-spells-1-speak-with-animals.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-speak-with-animals.md
@@ -1,0 +1,16 @@
+---
+title: Speak with Animals
+permalink: "/spells/first-level/speak-with-animals/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Druid, Ranger]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Divination (ritual)
+casting-time: "1 Action"
+range: "Self"
+components: "V, S"
+duration: "10 Minutes"
+---
+
+You gain the ability to comprehend and verbally communicate with beasts for the duration. The knowledge and awareness of many beasts is limited by their intelligence, but at minimum, beasts can give you information about nearby locations and monsters, including whatever they can perceive or have perceived within the past day. You might be able to persuade a beast to perform a small favor for you, at the GM’s discretion.

--- a/_posts/spells/first-level/2020-10-12-spells-1-thunderwave.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-thunderwave.md
@@ -1,0 +1,20 @@
+---
+title: Thunderwave
+permalink: "/spells/first-level/thunderwave/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Druid, Sorcerer, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Evocation
+casting-time: "1 Action"
+range: "Self (15-foot cube)"
+components: "V, S"
+duration: "Instantaneous"
+---
+
+A wave of thunderous force sweeps out from you. Each creature in a 15-foot cube originating from you must make a Constitution saving throw. On a failed save, a creature takes 2d8 thunder damage and is pushed 10 feet away from you. On a successful save, the creature takes half as much damage and isn’t pushed.
+
+In addition, unsecured objects that are completely within the area of effect are automatically pushed 10 feet away from you by the spell’s effect, and the spell emits a thunderous boom audible out to 300 feet.
+
+***At Higher Levels.*** When you cast this spell using a spell slot of 2nd level or higher, you deal an additional 1d8 damage for each slot level above 1st.

--- a/_posts/spells/first-level/2020-10-12-spells-1-unseen-servant.md
+++ b/_posts/spells/first-level/2020-10-12-spells-1-unseen-servant.md
@@ -1,0 +1,20 @@
+---
+title: Unseen Servant
+permalink: "/spells/first-level/unseen-servant/"
+layout: spell-post
+categories: [Spells, First Level]
+tags: [Bard, Warlock, Wizard]
+source: "Basic Rules (PHB)"
+spell-level: "1st-level"
+school: Conjuration (ritual)
+casting-time: "1 Action"
+range: "60 Feet"
+components: "V, S, M (A piece of string and a bit of wood)"
+duration: "1 Hour"
+---
+
+This spell creates an invisible, mindless, shapeless force that performs simple tasks at your command until the spell ends. The servant springs into existence in an unoccupied space on the ground within range. It has AC 10, 1 hit point, and a Strength of 2, and it can’t attack. If it drops to 0 hit points, the spell ends.
+
+Once on each of your turns as a bonus action, you can mentally command the servant to move up to 15 feet and interact with an object. The servant can perform simple tasks that a human servant could do, such as fetching things, cleaning, mending, folding clothes, lighting fires, serving food, and pouring wine. Once you give the command, the servant performs the task to the best of its ability until it completes the task, then waits for your next command.
+
+If you command the servant to perform a task that would move it more than 60 feet away from you, the spell ends.


### PR DESCRIPTION
Added markdown files for 1st level spells for those found in basic rules, which includes:
* Entangle
* Expeditious Retreat
* Faerie Fire
* False Life
* Feather Fall
* Find Familiar
* Fog Cloud
* Goodberry
* Grease
* Guiding Bolt
* Healing Word
* Hellish Rebuke
* Heroism
* Hunter's Mark
* Identify
* Illusory Script
* Inflict Wounds
* Jump
* Longstrider
* Mage Armor
* Magic Missile
* Protection from Evil and Good
* Purify Food and Drink
* Sanctuary
* Shield of Faith
* Shield
* Silent Image
* Sleep
* Speak with Animals
* Thunderwave
* Unseen Servant

Part of https://github.com/magicalmusings/magicalmusings.github.io/issues/21